### PR TITLE
feat: add alerts label to more metrics

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust AS builder
+FROM rust:1.88 AS builder
 
 RUN apt update && \
     apt install -y pkg-config libssl-dev perl make git

--- a/src/blockchains/cometbft/block/block.rs
+++ b/src/blockchains/cometbft/block/block.rs
@@ -515,6 +515,7 @@ impl Block {
                 &block_proposer,
                 &self.app_context.chain_id,
                 &self.app_context.config.general.network,
+                &validator_alert_addresses.contains(&block_proposer).to_string(),
             ])
             .inc();
 

--- a/src/blockchains/cometbft/metrics.rs
+++ b/src/blockchains/cometbft/metrics.rs
@@ -21,7 +21,7 @@ lazy_static! {
             "rcosmos_cometbft_validator_proposer_priority",
             "Validator proposer priority on the network"
         ),
-        &["address", "chain_id", "network"]
+        &["address", "chain_id", "network", "alerts"]
     )
     .unwrap();
     pub static ref COMETBFT_BLOCK_TXS: GaugeVec = GaugeVec::new(
@@ -92,7 +92,7 @@ lazy_static! {
             "rcosmos_cometbft_validator_proposed_blocks",
             "Number of blocks proposed by validator"
         ),
-        &["address", "chain_id", "network"]
+        &["address", "chain_id", "network", "alerts"]
     )
     .unwrap();
     pub static ref COMETBFT_VALIDATOR_BLOCKWINDOW_UPTIME: GaugeVec = GaugeVec::new(

--- a/src/blockchains/cometbft/validators.rs
+++ b/src/blockchains/cometbft/validators.rs
@@ -84,6 +84,7 @@ impl Validators {
                     &validator.address,
                     &self.app_context.chain_id,
                     &self.app_context.config.general.network,
+                    &alert_addresses.contains(&validator.address).to_string(),
                 ])
                 .set(validator.proposer_priority.parse::<i64>().unwrap_or(0));
 


### PR DESCRIPTION
- Add alerts label for `rcosmos_cometbft_validator_voting_power` and `rcosmos_cometbft_validator_proposed_blocks`

- Also fix the following crashloop error coming from the latest rust image version (1.89) by pinning the last working version (1.88):
```
./rcosmos-exporter: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by ./rcosmos-exporter)
```